### PR TITLE
Make LAPACK/BLAS detection and OMP handling more robust

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,13 +38,23 @@ if(WITH_MPI)
   endif()
 endif()
 
-if(WITH_OMP AND NOT TARGET OpenMP::OpenMP_Fortran)
-  find_package(OpenMP REQUIRED)
-  # Fix CMake bug on OpenMP settings for the NAG compiler
-  # See https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-  if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "NAG" AND WITH_OMP)
-    set_property(TARGET OpenMP::OpenMP_Fortran PROPERTY INTERFACE_LINK_LIBRARIES "")
-    set_property(TARGET OpenMP::OpenMP_Fortran PROPERTY INTERFACE_LINK_OPTIONS "-openmp")
+if(WITH_OMP)
+  if(NOT TARGET OpenMP::OpenMP_Fortran)
+    find_package(OpenMP REQUIRED)
+    # Fix CMake bug on OpenMP settings for the NAG compiler
+    # See https://gitlab.kitware.com/cmake/cmake/-/issues/21280
+    if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "NAG" AND WITH_OMP)
+      set_property(TARGET OpenMP::OpenMP_Fortran PROPERTY INTERFACE_LINK_LIBRARIES "")
+      set_property(TARGET OpenMP::OpenMP_Fortran PROPERTY INTERFACE_LINK_OPTIONS "-openmp")
+    endif()
+  endif()
+else()
+  # Create empty targets, so that subprojects can depend on it without actual effect
+  if(NOT TARGET OpenMP::OpenMP_Fortran)
+    add_library(OpenMP::OpenMP_Fortran INTERFACE IMPORTED)
+  endif()
+  if(NOT TARGET OpenMP::OpenMP_C)
+    add_library(OpenMP::OpenMP_C INTERFACE IMPORTED)
   endif()
 endif()
 
@@ -92,8 +102,9 @@ if(WITH_PLUMED)
   list(APPEND PKG_CONFIG_REQUIRES plumed)
 endif()
 
+find_package(CustomBlas REQUIRED)
 find_package(CustomLapack REQUIRED)
-list(APPEND PKG_CONFIG_LIBS_PRIVATE ${LAPACK_LIBRARY})
+list(APPEND PKG_CONFIG_LIBS_PRIVATE ${BLAS_LIBRARY} ${LAPACK_LIBRARY})
 
 if(WITH_ARPACK)
   find_package(CustomArpack REQUIRED)

--- a/cmake/Modules/FindCustomBlas.cmake
+++ b/cmake/Modules/FindCustomBlas.cmake
@@ -1,0 +1,126 @@
+# Distributed under the OSI-approved BSD 2-Clause License.
+#
+# Copyright (C) 2021 DFTB+ developers group
+#
+
+#[=======================================================================[.rst:
+FindCustomBlas
+----------------
+
+Finds the BLAS library
+
+This is a wrapper around CMakes FindBLAS module with the additional
+possibility to customize the library name manually. In latter case the module will
+check the existence of those libraries and stop if they are not found.
+
+Note: The module is named FindBlas (and not FindBLAS) to avoid name
+collision with CMakes built-in FindBLAS module.
+
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported target, if found:
+
+``BLAS::BLAS``
+  The BLAS library
+
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module will define the following variable:
+
+``BLAS_FOUND``
+  True if the system has the BLAS library
+
+
+Cache variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may be set to influence the library detection:
+
+``BLAS_DETECTION``
+  Whether BLAS libraries should be detected (default: True). If set to False,
+  the settings in ``BLAS_LIBRARY`` will be used without any further checks.
+
+``BLAS_LIBRARY``
+  Customized BLAS library/libraries to use (instead of autodetected ones).  If
+  no BLAS library is required (e.g. the linker automatically links it) set
+  ``BLAS_LIBRARY="NONE"``. If not set or empty, the built-in BLAS finder
+  (the findBLAS module) will be invoked. Otherwise, the listed libraries
+  will be checked for existence (unless disabled in ``BLAS_DETECTION``) and
+  the variable is overwritten to contain the libraries with their with full
+  path.
+
+``BLAS_LIBRARY_DIR``
+  Directories which should be looked up in order to find the customized libraries.
+
+``BLAS_LINKER_FLAG``
+  Flags to use when linking BLAS
+
+Additionally, the cache variables of the built-in FindBLAS modules may used to
+influence the BLAS detection if the built-in module is invoked.
+
+#]=======================================================================]
+
+include(FindPackageHandleStandardArgs)
+include(CustomLibraryFinder)
+
+if(TARGET BLAS::BLAS)
+
+  set(CUSTOMBLAS_FOUND True)
+  set(CustomBlas_FOUND True)
+  set(BLAS_FOUND True)
+  set(Blas_FOUND True)
+
+else()
+
+  option(BLAS_DETECTION "Whether BLAS library should be detected" TRUE)
+
+  if(BLAS_DETECTION)
+    # BLAS has either not been found yet or it was found by an older built-in findBLAS module.
+    # which does not provide the imported target BLAS::BLAS
+
+    if("${BLAS_LIBRARY}" STREQUAL "")
+
+      # No user customized BLAS library, try built-in finder
+      if(NOT BLAS_FOUND)
+        find_package(BLAS)
+      endif()
+      set(BLAS_LIBRARY "${BLAS_LIBRARIES}" CACHE STRING "BLAS library to link" FORCE)
+      set(BLAS_LINKER_FLAG "${BLAS_LINKER_FLAGS}" CACHE STRING
+        "Linker flags to use when linking BLAS" FORCE)
+
+    elseif(NOT "${BLAS_LIBRARY}" STREQUAL "NONE")
+
+      # BLAS explicitely set by the user, search for those libraries
+      find_custom_libraries("${BLAS_LIBRARY}" "${BLAS_LIBRARY_DIR}"
+        "${CustomBlas_FIND_QUIETLY}" _libs)
+      set(BLAS_LIBRARY "${_libs}" CACHE STRING "List of BLAS libraries to link" FORCE)
+      unset(_libs)
+
+    endif()
+
+    set(BLAS_DETECTION False CACHE BOOL "Whether BLAS libraries should be detected" FORCE)
+
+  endif()
+
+  find_package_handle_standard_args(CustomBlas REQUIRED_VARS BLAS_LIBRARY)
+
+  set(BLAS_FOUND ${CUSTOMBLAS_FOUND})
+  set(Blas_FOUND ${CUSTOMBLAS_FOUND})
+
+  if (BLAS_FOUND AND NOT TARGET BLAS::BLAS)
+    add_library(BLAS::BLAS INTERFACE IMPORTED)
+    if(NOT "${BLAS_LIBRARY}" STREQUAL "NONE")
+      target_link_libraries(BLAS::BLAS INTERFACE "${BLAS_LIBRARY}")
+    endif()
+    if(NOT "${BLAS_LINKER_FLAG}" STREQUAL "")
+      target_link_options(BLAS::BLAS INTERFACE "${BLAS_LINKER_FLAG}")
+    endif()
+  endif()
+
+  mark_as_advanced(BLAS_DETECTION BLAS_LIBRARY BLAS_LIBRARY_DIR BLAS_LINKER_FLAG)
+
+endif()

--- a/cmake/Modules/FindCustomLapack.cmake
+++ b/cmake/Modules/FindCustomLapack.cmake
@@ -111,21 +111,16 @@ else()
   set(LAPACK_FOUND ${CUSTOMLAPACK_FOUND})
   set(Lapack_FOUND ${CUSTOMLAPACK_FOUND})
 
-
-  # Ugly workaround: CMake's built-in LAPACK finder sometimes creates a LAPACK:LAPACK target
-  # (e.g. on MacOS) which does not contain all entries from ${LAPACK_LIBRARIES}. It is, therefore,
-  # added it here once more explicitely. If things worked correctly, this branch
-  #
-  #if (LAPACK_FOUND AND NOT TARGET LAPACK::LAPACK)
-  if(LAPACK_FOUND)
-    if (NOT TARGET LAPACK::LAPACK)
-      add_library(LAPACK::LAPACK INTERFACE IMPORTED)
-    endif()
+  if (LAPACK_FOUND AND NOT TARGET LAPACK::LAPACK)
+    add_library(LAPACK::LAPACK INTERFACE IMPORTED)
     if(NOT "${LAPACK_LIBRARY}" STREQUAL "NONE")
       target_link_libraries(LAPACK::LAPACK INTERFACE "${LAPACK_LIBRARY}")
     endif()
     if(NOT "${LAPACK_LINKER_FLAG}" STREQUAL "")
       target_link_options(LAPACK::LAPACK INTERFACE "${LAPACK_LINKER_FLAG}")
+    endif()
+    if(TARGET BLAS::BLAS)
+      target_link_libraries(LAPACK::LAPACK INTERFACE BLAS::BLAS)
     endif()
   endif()
 

--- a/prog/dftb+/CMakeLists.txt
+++ b/prog/dftb+/CMakeLists.txt
@@ -121,11 +121,9 @@ if(WITH_MPI)
   target_link_libraries(dftbplus PUBLIC MpiFx::MpiFx ScalapackFx::ScalapackFx)
 endif()
 
-if(WITH_OMP)
-  # OpenMP dependency must be public in order to forward eventual linker flags
-  # (workaround for NAG compiler) to targets linking to it.
-  target_link_libraries(dftbplus PUBLIC OpenMP::OpenMP_Fortran)
-endif()
+# OpenMP dependency must be public in order to forward eventual linker flags
+# (workaround for NAG compiler) to targets linking to it.
+target_link_libraries(dftbplus PUBLIC OpenMP::OpenMP_Fortran)
 
 if(WITH_ARPACK)
   target_link_libraries(dftbplus PRIVATE Arpack::Arpack)

--- a/sys/gnu-mkl-static.cmake
+++ b/sys/gnu-mkl-static.cmake
@@ -86,10 +86,12 @@ target_link_options(OpenMP::OpenMP_Fortran INTERFACE "-fopenmp")
 # sure your CMAKE_PREFIX_PATH variable is set up accordingly.
 
 # LAPACK and BLAS
-set(LAPACK_LIBRARY "-Wl,--start-group -lmkl_gf_lp64 -lmkl_gnu_thread -lmkl_core -Wl,--end-group"
-  CACHE STRING "LAPACK libraries")
-#set(LAPACK_LIBRARY_DIR "" CACHE STRING
-#  "Directories where LAPACK and BLAS libraries can be found")
+# (if the BLAS library contains the LAPACK functions, set LAPACK_LIBRARY to "NONE")
+set(BLAS_LIBRARY "-Wl,--start-group -lmkl_gf_lp64 -lmkl_gnu_thread -lmkl_core -Wl,--end-group"
+  CACHE STRING "BLAS libraries")
+#set(BLAS_LIBRARY_DIR "" CACHE STRING "Directories where BLAS libraries can be found")
+set(LAPACK_LIBRARY "NONE" CACHE STRING "LAPACK libraries")
+#set(LAPACK_LIBRARY_DIR "" CACHE STRING "Directories where LAPACK libraries can be found")
 
 # ARPACK -- only needed when built with ARPACK support
 set(ARPACK_LIBRARY "libarpack.a" CACHE STRING "Arpack libraries")

--- a/sys/gnu.cmake
+++ b/sys/gnu.cmake
@@ -69,9 +69,11 @@ set(C_FLAGS_COVERAGE "-O0 -g --coverage")
 # sure your CMAKE_PREFIX_PATH variable is set up accordingly.
 
 # LAPACK and BLAS
-#set(LAPACK_LIBRARY "openblas" CACHE STRING "LAPACK and BLAS libraries to link")
-#set(LAPACK_LIBRARY_DIR "" CACHE STRING
-#  "Directories where LAPACK and BLAS libraries can be found")
+# (if the BLAS library contains the LAPACK functions, set LAPACK_LIBRARY to "NONE")
+#set(BLAS_LIBRARY "openblas" CACHE STRING "BLAS libraries to link")
+#set(BLAS_LIBRARY_DIR "" CACHE STRING "Directories where BLAS libraries can be found")
+#set(LAPACK_LIBRARY "NONE" CACHE STRING "LAPACK libraries to link")
+#set(LAPACK_LIBRARY_DIR "" CACHE STRING "Directories where LAPACK libraries can be found")
 
 # ARPACK -- only needed when built with ARPACK support
 #set(ARPACK_LIBRARY "arpack" CACHE STRING "Arpack libraries")

--- a/sys/intel.cmake
+++ b/sys/intel.cmake
@@ -56,16 +56,19 @@ set(C_FLAGS_DEBUG "-g -Wall"
 # sure your CMAKE_PREFIX_PATH variable is set up accordingly.
 
 # LAPACK and BLAS
+# (if the BLAS library contains the LAPACK functions, set LAPACK_LIBRARY to "NONE")
 if(WITH_OMP)
-  set(LAPACK_LIBRARY "mkl_intel_lp64;mkl_intel_thread;mkl_core" CACHE STRING
-    "LAPACK and BLAS libraries to link")
+  set(BLAS_LIBRARY "mkl_intel_lp64;mkl_intel_thread;mkl_core" CACHE STRING "BLAS library to link")
 else()
-  set(LAPACK_LIBRARY "mkl_intel_lp64;mkl_sequential;mkl_core" CACHE STRING
-    "LAPACK and BLAS libraries to link")
+  set(BLAS_LIBRARY "mkl_intel_lp64;mkl_sequential;mkl_core" CACHE STRING "BLAS libraries to link")
 endif()
+set(BLAS_LIBRARY_DIR "$ENV{MKLROOT}/lib/intel64" CACHE STRING
+    "Directories where BLAS libraries can be found")
 
-set(LAPACK_LIBRARY_DIR "$ENV{MKLROOT}/lib/intel64" CACHE STRING
-  "Directories where LAPACK and BLAS libraries can be found")
+set(LAPACK_LIBRARY "NONE")
+#set(LAPACK_LIBRARY_DIR "$ENV{MKLROOT}/lib/intel64" CACHE STRING
+#    "Directories where LAPACK libraries can be found")
+
 
 # ARPACK -- only needed when built with ARPACK support
 #set(ARPACK_LIBRARY "arpack" CACHE STRING "Arpack library")

--- a/sys/nag.cmake
+++ b/sys/nag.cmake
@@ -58,9 +58,11 @@ set(C_FLAGS_DEBUG "-g -Wall -pedantic -fbounds-check"
 # sure your CMAKE_PREFIX_PATH variable is set up accordingly.
 
 # LAPACK and BLAS
-#set(LAPACK_LIBRARY "openblas" CACHE STRING "LAPACK and BLAS libraries to link")
-#set(LAPACK_LIBRARY_DIR "" CACHE STRING
-#  "Directories where LAPACK and BLAS libraries can be found")
+# (if the BLAS library contains the LAPACK functions, set LAPACK_LIBRARY to "NONE")
+#set(BLAS_LIBRARY "openblas" CACHE STRING "BLAS libraries to link")
+#set(BLAS_LIBRARY_DIR "" CACHE STRING "Directories where BLAS libraries can be found")
+#set(LAPACK_LIBRARY "NONE" CACHE STRING "LAPACK libraries to link")
+#set(LAPACK_LIBRARY_DIR "" CACHE STRING "Directories where LAPACK libraries can be found")
 
 # ARPACK -- only needed when built with ARPACK support
 #set(ARPACK_LIBRARY "arpack" CACHE STRING "Arpack library")

--- a/utils/export/dftbplus-config.cmake.in
+++ b/utils/export/dftbplus-config.cmake.in
@@ -26,7 +26,11 @@ if(NOT TARGET DftbPlus::DftbPlus)
   if(DftbPlus_WITH_OMP AND NOT TARGET OpenMP::OpenMP_Fortran)
     find_dependency(OpenMP)
   endif()
-  
+
+  if(NOT TARGET BLAS::BLAS)
+    find_dependency(CustomBlas)
+  endif()
+
   if(NOT TARGET LAPACK::LAPACK)
     find_dependency(CustomLapack)
   endif()


### PR DESCRIPTION
* Fixes CMake issues with LAPACK/BLAS.
* Creates empty OpenMP::OpenMP_* tags if OpenMP is not desired: enables switching off OMP-support in subproject without variable remapping due to differing names.